### PR TITLE
Remove parent::setUp()

### DIFF
--- a/src/SnapMigrations.php
+++ b/src/SnapMigrations.php
@@ -31,8 +31,6 @@ trait SnapMigrations
 
         $this->shouldRunSeeder = $shouldRunSeeder;
 
-        parent::setUp();
-
         $this->runDatabaseMigrations($this->shouldRunSeeder);
     }
 


### PR DESCRIPTION
Call to parent::setUp() can cause segmentation errors.